### PR TITLE
Let seeders use table names specified in config

### DIFF
--- a/publishable/database/seeds/CitiesTableSeeder.php
+++ b/publishable/database/seeds/CitiesTableSeeder.php
@@ -11,8 +11,8 @@ class CitiesTableSeeder extends Seeder
      */
     public function run()
     {
-        //
-        DB::table('cities')->delete();
+        $citiesTable = config('laravel-location.cities_table', 'cities');
+        DB::table($citiesTable)->delete();
 
         $cities = array(
             array('name' => "Bombuflat",'state_id' => 1),
@@ -6018,7 +6018,7 @@ class CitiesTableSeeder extends Seeder
 
         );
 
-        DB::table('cities')->insert($cities);
+        DB::table($citiesTable)->insert($cities);
 
         $cities2 = array(
             array('name' => "Qal'eh-ye Zal",'state_id' => 67),
@@ -12024,7 +12024,7 @@ class CitiesTableSeeder extends Seeder
 
         );
 
-        DB::table('cities')->insert($cities2);
+        DB::table($citiesTable)->insert($cities2);
 
         $cities3 = array(
             array('name' => "Huanren",'state_id' => 755),
@@ -18030,7 +18030,7 @@ class CitiesTableSeeder extends Seeder
 
         );
 
-        DB::table('cities')->insert($cities3);
+        DB::table($citiesTable)->insert($cities3);
 
         $cities4 = array(
             array('name' => "Saint-Gratien",'state_id' => 1305),
@@ -24036,7 +24036,7 @@ class CitiesTableSeeder extends Seeder
 
         );
 
-        DB::table('cities')->insert($cities4);
+        DB::table($citiesTable)->insert($cities4);
 
         $cities5 = array(
 
@@ -30043,7 +30043,7 @@ class CitiesTableSeeder extends Seeder
 
         );
 
-        DB::table('cities')->insert($cities5);
+        DB::table($citiesTable)->insert($cities5);
 
         $cities6 = array(
 
@@ -36071,7 +36071,7 @@ class CitiesTableSeeder extends Seeder
 
         );
 
-        DB::table('cities')->insert($cities6);
+        DB::table($citiesTable)->insert($cities6);
 
         $cities7 = array(
 
@@ -42078,7 +42078,7 @@ class CitiesTableSeeder extends Seeder
 
         );
 
-        DB::table('cities')->insert($cities7);
+        DB::table($citiesTable)->insert($cities7);
 
         $cities8 = array(
 
@@ -48398,6 +48398,6 @@ class CitiesTableSeeder extends Seeder
             array('name' => "Summersville",'state_id' => 3976),
         );
 
-        DB::table('cities')->insert($cities8);
+        DB::table($citiesTable)->insert($cities8);
     }
 }

--- a/publishable/database/seeds/CountriesTableSeeder.php
+++ b/publishable/database/seeds/CountriesTableSeeder.php
@@ -11,7 +11,8 @@ class CountriesTableSeeder extends Seeder
      */
     public function run()
     {
-        DB::table('countries')->delete();
+        $countriesTable = config('laravel-location.countries_table', 'countries');
+        DB::table($countriesTable)->delete();
 
         $countries = array(
             array('id' => 1,'code' => 'AF' ,'name' => "Afghanistan",'phonecode' => 93),
@@ -262,6 +263,6 @@ class CountriesTableSeeder extends Seeder
             array('id' => 246,'code' => 'ZW','name' => "Zimbabwe",'phonecode' => 263),
         );
 
-        DB::table('countries')->insert($countries);
+        DB::table($countriesTable)->insert($countries);
     }
 }

--- a/publishable/database/seeds/StatesTableSeeder.php
+++ b/publishable/database/seeds/StatesTableSeeder.php
@@ -11,7 +11,8 @@ class StatesTableSeeder extends Seeder
      */
     public function run()
     {
-        DB::table('states')->delete();
+        $statesTable =   $citiesTable = config('laravel-location.states_table', 'states');
+        DB::table($statesTable)->delete();
 
         $states = array(
             array('name' => "Andaman and Nicobar Islands",'country_id' => 101),
@@ -4137,6 +4138,6 @@ class StatesTableSeeder extends Seeder
             array('name' => "Midlands",'country_id' => 246)
         );
 
-        DB::table('states')->insert($states);
+        DB::table($statesTable)->insert($states);
     }
 }


### PR DESCRIPTION
I notice the table names in the seeder are hardcoded and the package has a config file for user to specify table names. That means, that feature is not been used. So, I modified the package to use the table name specified in the config or use the default.