### PR TITLE
Use truncate() instead of delete() to keep IDs consistent

### DIFF
--- a/publishable/database/seeds/CitiesTableSeeder.php
+++ b/publishable/database/seeds/CitiesTableSeeder.php
@@ -12,7 +12,7 @@ class CitiesTableSeeder extends Seeder
     public function run()
     {
         $citiesTable = config('laravel-location.cities_table', 'cities');
-        DB::table($citiesTable)->delete();
+        DB::table($citiesTable)->truncate();
 
         $cities = array(
             array('name' => "Bombuflat",'state_id' => 1),

--- a/publishable/database/seeds/CountriesTableSeeder.php
+++ b/publishable/database/seeds/CountriesTableSeeder.php
@@ -12,7 +12,7 @@ class CountriesTableSeeder extends Seeder
     public function run()
     {
         $countriesTable = config('laravel-location.countries_table', 'countries');
-        DB::table($countriesTable)->delete();
+        DB::table($countriesTable)->truncate();
 
         $countries = array(
             array('id' => 1,'code' => 'AF' ,'name' => "Afghanistan",'phonecode' => 93),

--- a/publishable/database/seeds/StatesTableSeeder.php
+++ b/publishable/database/seeds/StatesTableSeeder.php
@@ -11,7 +11,7 @@ class StatesTableSeeder extends Seeder
      */
     public function run()
     {
-        $statesTable =   $citiesTable = config('laravel-location.states_table', 'states');
+        $statesTable  = config('laravel-location.states_table', 'states');
         DB::table($statesTable)->truncate();
 
         $states = array(

--- a/publishable/database/seeds/StatesTableSeeder.php
+++ b/publishable/database/seeds/StatesTableSeeder.php
@@ -12,7 +12,7 @@ class StatesTableSeeder extends Seeder
     public function run()
     {
         $statesTable =   $citiesTable = config('laravel-location.states_table', 'states');
-        DB::table($statesTable)->delete();
+        DB::table($statesTable)->truncate();
 
         $states = array(
             array('name' => "Andaman and Nicobar Islands",'country_id' => 101),


### PR DESCRIPTION
I think it's better to truncate the tables than use `delete()`; Using `delete()` will empty the table, but the autoincrement ID remains the same. So, next time the Seeder is run, IDs start counting from the last autoincrement instead of 1. This can lead to inconsistent data. Since all 3 tables are related, the IDs should remain the same irrespective of the number of times the seeders are run.

Another reason is that using `delete()` leaves the tendency for duplicates. The `name` column is not set to be unique. So, each time I run the seeder, an exact data is duplicated in the table.