### PR TITLE
removed db::truncate as it caused errors when tables were used as FK

### DIFF
--- a/src/database/seeds/CitiesTableSeeder.php
+++ b/src/database/seeds/CitiesTableSeeder.php
@@ -15,7 +15,6 @@ class CitiesTableSeeder extends Seeder
     public function run()
     {
         $citiesTable = config('location.cities_table', 'cities');
-        DB::table($citiesTable)->truncate();
 
         $cities = array(
             array('name' => "Bombuflat",'state_id' => 1),

--- a/src/database/seeds/CountriesTableSeeder.php
+++ b/src/database/seeds/CountriesTableSeeder.php
@@ -15,8 +15,6 @@ class CountriesTableSeeder extends Seeder
     public function run()
     {
         $countriesTable = config('location.countries_table', 'countries');
-        DB::table($countriesTable)->truncate();
-
         $countries = array(
             array('id' => 1,'code' => 'AF' ,'name' => "Afghanistan",'phonecode' => 93),
             array('id' => 2,'code' => 'AL' ,'name' => "Albania",'phonecode' => 355),

--- a/src/database/seeds/StatesTableSeeder.php
+++ b/src/database/seeds/StatesTableSeeder.php
@@ -15,7 +15,6 @@ class StatesTableSeeder extends Seeder
     public function run()
     {
         $statesTable  = config('location.states_table', 'states');
-        DB::table($statesTable)->truncate();
 
         $states = array(
             array('name' => "Andaman and Nicobar Islands",'country_id' => 101),


### PR DESCRIPTION
Removed db::truncate from seeders. It is unnecessary and it was causing errors when using of the tables as reference for FKs.

This solves #29