### PR TITLE
Truncate tables before seeding for consistent IDs

### DIFF
--- a/src/database/seeds/CitiesTableSeeder.php
+++ b/src/database/seeds/CitiesTableSeeder.php
@@ -14,6 +14,7 @@ class CitiesTableSeeder extends Seeder
     public function run()
     {
         $citiesTable = config('location.cities_table', 'cities');
+        DB::table($citiesTable)->truncate();
 
         $cities = array(
             array('name' => "Bombuflat",'state_id' => 1),

--- a/src/database/seeds/CitiesTableSeeder.php
+++ b/src/database/seeds/CitiesTableSeeder.php
@@ -3,6 +3,7 @@ namespace Ichtrojan\Location\Seeds;
 
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 class CitiesTableSeeder extends Seeder
 {
@@ -14,7 +15,10 @@ class CitiesTableSeeder extends Seeder
     public function run()
     {
         $citiesTable = config('location.cities_table', 'cities');
+        
+         Schema::disableForeignKeyConstraints();
         DB::table($citiesTable)->truncate();
+         Schema::enableForeignKeyConstraints();
 
         $cities = array(
             array('name' => "Bombuflat",'state_id' => 1),

--- a/src/database/seeds/CountriesTableSeeder.php
+++ b/src/database/seeds/CountriesTableSeeder.php
@@ -3,6 +3,7 @@ namespace Ichtrojan\Location\Seeds;
 
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 class CountriesTableSeeder extends Seeder
 {
@@ -263,7 +264,10 @@ class CountriesTableSeeder extends Seeder
             array('id' => 246,'code' => 'ZW','name' => "Zimbabwe",'phonecode' => 263),
         );
 
+        // Fix for issue #29 https://github.com/ichtrojan/laravel-location/issues/29
+        Schema::disableForeignKeyConstraints();
         DB::table($countriesTable)->truncate();
+        Schema::enableForeignKeyConstraints();
         DB::table($countriesTable)->insert($countries);
     }
 }

--- a/src/database/seeds/CountriesTableSeeder.php
+++ b/src/database/seeds/CountriesTableSeeder.php
@@ -263,6 +263,7 @@ class CountriesTableSeeder extends Seeder
             array('id' => 246,'code' => 'ZW','name' => "Zimbabwe",'phonecode' => 263),
         );
 
+        DB::table($countriesTable)->truncate();
         DB::table($countriesTable)->insert($countries);
     }
 }

--- a/src/database/seeds/StatesTableSeeder.php
+++ b/src/database/seeds/StatesTableSeeder.php
@@ -4138,7 +4138,7 @@ class StatesTableSeeder extends Seeder
             array('name' => "Matabeleland South",'country_id' => 246),
             array('name' => "Midlands",'country_id' => 246)
         );
-
+        DB::table($statesTable)->truncate();
         DB::table($statesTable)->insert($states);
     }
 }

--- a/src/database/seeds/StatesTableSeeder.php
+++ b/src/database/seeds/StatesTableSeeder.php
@@ -3,6 +3,7 @@ namespace Ichtrojan\Location\Seeds;
 
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 class StatesTableSeeder extends Seeder
 {
@@ -4138,7 +4139,9 @@ class StatesTableSeeder extends Seeder
             array('name' => "Matabeleland South",'country_id' => 246),
             array('name' => "Midlands",'country_id' => 246)
         );
+        Schema::disableForeignKeyConstraints();
         DB::table($statesTable)->truncate();
+        Schema::enableForeignKeyConstraints();
         DB::table($statesTable)->insert($states);
     }
 }


### PR DESCRIPTION
- Tables should be truncated before seeding, else it might throw error duplicate ID if the table isn't empty