### PR TITLE
Added illuminate/support ^8.0 for fix problem with installation in laravel 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		}
 	},
 	"require": {
-		"illuminate/support": "^5.0|^6.0|^7.0"
+		"illuminate/support": "^5.0 || ^6.0 || ^7.0 || ^8.0"
 	},
 	"require-dev": {
 		"mockery/mockery": "^1.0",


### PR DESCRIPTION
Also changed `|` to `||` in version condition. 

This changes fix problem below:
```
Problem 1
    - Installation request for ichtrojan/laravel-location ^3.2 -> satisfiable by ichtrojan/laravel-location[v3.2.0].
    - Conclusion: remove laravel/framework v8.6.0
    - Conclusion: don't install laravel/framework v8.6.0
    - ichtrojan/laravel-location v3.2.0 requires illuminate/support ^5.0|^6.0|^7.0 -> satisfiable by laravel/framework[5.4.x-dev, 5.5.x-dev, 5.6.x-dev, 5.7.x-dev, 5.8.x-dev, 6.x-dev, 7.x-dev], illuminate/support[5.0.x-dev, 5.1.x-dev, 5.2.x-dev, 5.3.x-dev, 5.4.x-dev, 5.5.x-dev, 5.6.x-dev, 5.7.17, 5.7.18, 5.7.19, 5.7.x-dev, 5.8.x-dev, 6.x-dev, 7.x-dev, v5.0.0, v5.0.22, v5.0.25, v5.0.26, v5.0.28, v5.0.33, v5.0.4, v5.1.1, v5.1.13, v5.1.16, v5.1.2, v5.1.20, v5.1.22, v5.1.25, v5.1.28, v5.1.30, v5.1.31, v5.1.41, v5.1.6, v5.1.8, v5.2.0, v5.2.19, v5.2.21, v5.2.24, v5.2.25, v5.2.26, v5.2.27, v5.2.28, v5.2.31, v5.2.32, v5.2.37, v5.2.43, v5.2.45, v5.2.6, v5.2.7, v5.3.0, v5.3.16, v5.3.23, v5.3.4, v5.4.0, v5.4.13, v5.4.17, v5.4.19, v5.4.27, v5.4.36, v5.4.9, v5.5.0, v5.5.16, v5.5.17, v5.5.2, v5.5.28, v5.5.33, v5.5.34, v5.5.35, v5.5.36, v5.5.37, v5.5.39, v5.5.40, v5.5.41, v5.5.43, v5.5.44, v5.6.0, v5.6.1, v5.6.10, v5.6.11, v5.6.12, v5.6.13, v5.6.14, v5.6.15, v5.6.16, v5.6.17, v5.6.19, v5.6.2, v5.6.20, v5.6.21, v5.6.22, v5.6.23, v5.6.24, v5.6.25, v5.6.26, v5.6.27, v5.6.28, v5.6.29, v5.6.3, v5.6.30, v5.6.31, v5.6.32, v5.6.33, v5.6.34, v5.6.35, v5.6.36, v5.6.37, v5.6.38, v5.6.39, v5.6.4, v5.6.5, v5.6.6, v5.6.7, v5.6.8, v5.6.9, v5.7.0, v5.7.1, v5.7.10, v5.7.11, v5.7.15, v5.7.2, v5.7.20, v5.7.21, v5.7.22, v5.7.23, v5.7.26, v5.7.27, v5.7.28, v5.7.3, v5.7.4, v5.7.5, v5.7.6, v5.7.7, v5.7.8, v5.7.9, v5.8.0, v5.8.11, v5.8.12, v5.8.14, v5.8.15, v5.8.17, v5.8.18, v5.8.19, v5.8.2, v5.8.20, v5.8.22, v5.8.24, v5.8.27, v5.8.28, v5.8.29, v5.8.3, v5.8.30, v5.8.31, v5.8.32, v5.8.33, v5.8.34, v5.8.35, v5.8.36, v5.8.4, v5.8.8, v5.8.9, v6.0.0, v6.0.1, v6.0.2, v6.0.3, v6.0.4, v6.1.0, v6.10.0, v6.11.0, v6.12.0, v6.13.0, v6.13.1, v6.14.0, v6.15.0, v6.15.1, v6.16.0, v6.17.0, v6.17.1, v6.18.0, v6.18.1, v6.18.10, v6.18.11, v6.18.12, v6.18.13, v6.18.14, v6.18.15, v6.18.16, v6.18.17, v6.18.18, v6.18.19, v6.18.2, v6.18.20, v6.18.21, v6.18.22, v6.18.23, v6.18.24, v6.18.25, v6.18.26, v6.18.27, v6.18.28, v6.18.29, v6.18.3, v6.18.30, v6.18.31, v6.18.32, v6.18.33, v6.18.34, v6.18.35, v6.18.36, v6.18.37, v6.18.38, v6.18.39, v6.18.4, v6.18.40, v6.18.5, v6.18.6, v6.18.7, v6.18.8, v6.18.9, v6.2.0, v6.3.0, v6.4.1, v6.5.0, v6.5.1, v6.5.2, v6.6.0, v6.6.1, v6.6.2, v6.7.0, v6.8.0, v7.0.0, v7.0.1, v7.0.2, v7.0.3, v7.0.4, v7.0.5, v7.0.6, v7.0.7, v7.0.8, v7.1.0, v7.1.1, v7.1.2, v7.1.3, v7.10.0, v7.10.1, v7.10.2, v7.10.3, v7.11.0, v7.12.0, v7.13.0, v7.14.0, v7.14.1, v7.15.0, v7.16.0, v7.16.1, v7.17.0, v7.17.1, v7.17.2, v7.18.0, v7.19.0, v7.19.1, v7.2.0, v7.2.1, v7.2.2, v7.20.0, v7.21.0, v7.22.0, v7.22.1, v7.22.2, v7.22.3, v7.22.4, v7.23.0, v7.23.1, v7.23.2, v7.24.0, v7.25.0, v7.26.0, v7.26.1, v7.27.0, v7.28.0, v7.28.1, v7.28.2, v7.28.3, v7.3.0, v7.4.0, v7.5.0, v7.5.1, v7.5.2, v7.6.0, v7.6.1, v7.6.2, v7.7.0, v7.7.1, v7.8.0, v7.8.1, v7.9.0, v7.9.1, v7.9.2].
    - Can only install one of: laravel/framework[6.x-dev, v8.6.0].
    - Can only install one of: laravel/framework[7.x-dev, v8.6.0].
    - Can only install one of: laravel/framework[5.4.x-dev, v8.6.0].
    - Can only install one of: laravel/framework[5.5.x-dev, v8.6.0].
    - Can only install one of: laravel/framework[5.6.x-dev, v8.6.0].
    - Can only install one of: laravel/framework[5.7.x-dev, v8.6.0].
    - Can only install one of: laravel/framework[5.8.x-dev, v8.6.0].
    - don't install illuminate/support 6.x-dev|don't install laravel/framework v8.6.0
    - don't install illuminate/support 7.x-dev|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.0.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.0.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.0.2|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.0.3|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.0.4|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.1.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.10.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.11.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.12.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.13.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.13.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.14.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.15.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.15.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.16.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.17.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.17.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.10|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.11|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.12|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.13|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.14|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.15|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.16|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.17|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.18|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.19|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.2|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.20|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.21|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.22|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.23|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.24|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.25|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.26|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.27|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.28|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.29|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.3|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.30|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.31|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.32|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.33|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.34|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.35|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.36|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.37|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.38|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.39|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.4|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.40|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.5|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.6|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.7|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.8|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.18.9|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.2.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.3.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.4.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.5.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.5.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.5.2|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.6.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.6.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.6.2|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.7.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v6.8.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.0.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.0.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.0.2|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.0.3|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.0.4|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.0.5|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.0.6|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.0.7|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.0.8|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.1.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.1.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.1.2|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.1.3|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.10.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.10.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.10.2|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.10.3|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.11.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.12.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.13.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.14.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.14.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.15.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.16.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.16.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.17.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.17.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.17.2|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.18.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.19.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.19.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.2.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.2.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.2.2|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.20.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.21.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.22.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.22.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.22.2|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.22.3|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.22.4|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.23.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.23.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.23.2|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.24.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.25.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.26.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.26.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.27.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.28.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.28.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.28.2|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.28.3|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.3.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.4.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.5.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.5.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.5.2|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.6.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.6.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.6.2|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.7.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.7.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.8.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.8.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.9.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.9.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v7.9.2|don't install laravel/framework v8.6.0
    - don't install illuminate/support 5.6.x-dev|don't install laravel/framework v8.6.0
    - don't install illuminate/support 5.7.17|don't install laravel/framework v8.6.0
    - don't install illuminate/support 5.7.18|don't install laravel/framework v8.6.0
    - don't install illuminate/support 5.7.19|don't install laravel/framework v8.6.0
    - don't install illuminate/support 5.7.x-dev|don't install laravel/framework v8.6.0
    - don't install illuminate/support 5.8.x-dev|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.10|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.11|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.12|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.13|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.14|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.15|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.16|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.17|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.19|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.2|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.20|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.21|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.22|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.23|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.24|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.25|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.26|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.27|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.28|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.29|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.3|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.30|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.31|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.32|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.33|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.34|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.35|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.36|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.37|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.38|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.39|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.4|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.5|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.6|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.7|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.8|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.6.9|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.7.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.7.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.7.10|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.7.11|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.7.15|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.7.2|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.7.20|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.7.21|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.7.22|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.7.23|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.7.26|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.7.27|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.7.28|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.7.3|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.7.4|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.7.5|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.7.6|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.7.7|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.7.8|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.7.9|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.11|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.12|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.14|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.15|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.17|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.18|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.19|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.2|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.20|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.22|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.24|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.27|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.28|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.29|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.3|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.30|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.31|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.32|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.33|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.34|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.35|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.36|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.4|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.8|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.8.9|don't install laravel/framework v8.6.0
    - don't install illuminate/support 5.1.x-dev|don't install laravel/framework v8.6.0
    - don't install illuminate/support 5.2.x-dev|don't install laravel/framework v8.6.0
    - don't install illuminate/support 5.3.x-dev|don't install laravel/framework v8.6.0
    - don't install illuminate/support 5.4.x-dev|don't install laravel/framework v8.6.0
    - don't install illuminate/support 5.5.x-dev|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.1.1|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.1.13|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.1.16|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.1.2|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.1.20|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.1.22|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.1.25|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.1.28|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.1.30|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.1.31|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.1.41|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.1.6|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.1.8|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.2.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.2.19|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.2.21|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.2.24|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.2.25|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.2.26|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.2.27|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.2.28|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.2.31|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.2.32|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.2.37|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.2.43|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.2.45|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.2.6|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.2.7|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.3.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.3.16|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.3.23|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.3.4|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.4.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.4.13|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.4.17|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.4.19|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.4.27|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.4.36|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.4.9|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.5.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.5.16|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.5.17|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.5.2|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.5.28|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.5.33|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.5.34|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.5.35|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.5.36|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.5.37|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.5.39|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.5.40|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.5.41|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.5.43|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.5.44|don't install laravel/framework v8.6.0
    - don't install illuminate/support 5.0.x-dev|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.0.0|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.0.22|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.0.25|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.0.26|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.0.28|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.0.33|don't install laravel/framework v8.6.0
    - don't install illuminate/support v5.0.4|don't install laravel/framework v8.6.0
    - Installation request for laravel/framework (locked at v8.6.0, required as ^8.0) -> satisfiable by laravel/framework[v8.6.0].
```

If it`s okay, after approve please update package minor version. Thank you!