### PR TITLE
Finxing wrong state name of bangladesh

### DIFF
--- a/src/database/seeds/StatesTableSeeder.php
+++ b/src/database/seeds/StatesTableSeeder.php
@@ -413,7 +413,7 @@ class StatesTableSeeder extends Seeder
             array('name' => "Satkhira",'country_id' => 18),
             array('name' => "Shariatpur",'country_id' => 18),
             array('name' => "Sherpur",'country_id' => 18),
-            array('name' => "Silhat",'country_id' => 18),
+            array('name' => "Sylhet",'country_id' => 18),
             array('name' => "Sirajganj",'country_id' => 18),
             array('name' => "Sunamganj",'country_id' => 18),
             array('name' => "Tangayal",'country_id' => 18),


### PR DESCRIPTION
State id 397,Country id 18.current name is "Silhat".But the name should be "Sylhet".
that's why proposing the change